### PR TITLE
Fixing bug initializing the ManufacturerDataMask

### DIFF
--- a/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/ScanFilterUtils.java
+++ b/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/ScanFilterUtils.java
@@ -33,7 +33,9 @@ public final class ScanFilterUtils
         // the manufacturer data byte is the filter!
         final byte[] manufacturerData = new byte[]
         {
-                0,0,
+
+                // identify as iBeacon
+                (byte)0x02,(byte)0x15,
 
                 // uuid
                 0,0,0,0,
@@ -53,19 +55,20 @@ public final class ScanFilterUtils
         // the mask tells what bytes in the filter need to match, 1 if it has to match, 0 if not
         final byte[] manufacturerDataMask = new byte[]
         {
-                0,0,
+                // Type and length
+                (byte)0xFF,(byte)0xFF,
 
                 // uuid
-                1,1,1,1,
-                1,1,
-                1,1,
-                1,1,1,1,1,1,1,1,
+                (byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF,
+                (byte)0xFF,(byte)0xFF,
+                (byte)0xFF,(byte)0xFF,
+                (byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF,
 
                 // major
-                1,1,
+                (byte)0xFF,(byte)0xFF,
 
                 // minor
-                1,1,
+                (byte)0xFF,(byte)0xFF,
 
                 0
         };


### PR DESCRIPTION
Bytes of the DataMask are initialised with 0b00000001 instead of
0b11111111, hence only the least significant bit of the DataMask and the
result data are being compared. Effectively the current FilterMask is just an
even/odd filter for the selected bytes.

Also added the iBeacon type identifier (0x02) as well as length byte
(0x21) to the filter mask. I understand this is done in the
onScanResult method @ScannerScanCallback, however, as type byte and
length are fixed this will reduce unnecessary callbacks.